### PR TITLE
Make usage of only necessary cookies obvious.

### DIFF
--- a/client/src/components/account/CookiesModal.tsx
+++ b/client/src/components/account/CookiesModal.tsx
@@ -47,7 +47,7 @@ export default function CookieModal() {
                         <div className="textcontent">
                             <p className="cmdtxt">We only use cookies and data that are necessary to provide and maintain RapidTyper.</p>
                             <p className="cmdtxt">
-                                By accepting the cookies you also agree to comply with our terms of service{" "}
+                                By continuing to use this site, you accept all necessary cookies and also agree to comply with our terms of service{" "}
                                 <a className="cmd_link" href="https://grovider.co/privacy-policy">
                                     Privacy Policy
                                 </a>{" "}
@@ -57,14 +57,13 @@ export default function CookieModal() {
                                 </Link>
                                 .
                             </p>
-                            <p className="cmdtxt">In order for RapidTyper to work, you must accept all cookies, as only necessary cookies are used.</p>
                             <p className="errtxt_clr">{errMsg}</p>
                             <div className="_c_buttonset">
                                 <button className="secondary_action" onClick={handleWrong}>
                                     I decline
                                 </button>
                                 <button onClick={handleAccept} ref={tab}>
-                                    I accept all
+                                    I understand
                                 </button>
                             </div>
                         </div>


### PR DESCRIPTION
When I first visited RapidTyper, I didn't realize that the *I accept all* option in the cookie consent modal would only accept necessary cookies. Using a button like *I understand* with a slightly modified text above it seems more suitable.