### PR TITLE
Add non-breaking space after copyright symbol in footer

### DIFF
--- a/client/src/components/footer/Footer.tsx
+++ b/client/src/components/footer/Footer.tsx
@@ -53,7 +53,7 @@ export default function Footer() {
                 </ul>
                 <div className="copyright">
                     <p className="copyrighttxt">
-                        &copy;2023 RapidTyper - von{" "}
+                        &copy;&nbsp;2023 RapidTyper - von{" "}
                         <a style={{ textDecoration: "none", color: "white" }} target="_blank" rel="noreferrer" href="https://www.instagram.com/baum062/" onClick={() => handleSkin("capybara")}>
                             Luis
                         </a>{" "}


### PR DESCRIPTION
Add a non-breaking space (\&nbsp;) between the copyright sign (\&copy;) and the year (2023). According to [[1]](https://ux.stackexchange.com/questions/50875/should-there-be-a-space-after-the-copyright-symbol) and [[2]](https://www.copyrightlaws.com/copyright-symbol-notice-year/), this is the semantically correct version.

P.S. _Went from this (_ &copy;2023 _) to this (_ &copy;&nbsp;2023 _)._