### PR TITLE
Replace minus sign in footer with em dash

### DIFF
--- a/client/src/components/footer/Footer.tsx
+++ b/client/src/components/footer/Footer.tsx
@@ -53,7 +53,7 @@ export default function Footer() {
                 </ul>
                 <div className="copyright">
                     <p className="copyrighttxt">
-                        &copy;2023 RapidTyper - von{" "}
+                        &copy;2023 RapidTyper &mdash; von{" "}
                         <a style={{ textDecoration: "none", color: "white" }} target="_blank" rel="noreferrer" href="https://www.instagram.com/baum062/" onClick={() => handleSkin("capybara")}>
                             Luis
                         </a>{" "}


### PR DESCRIPTION
A minus sign is not correct in this place, as it can only be used as a mathematical symbol or for word hyphenation.
I replaced it with an em dash (\&mdash;), which is slightly (but noticeably!) longer than a normal dash.

P.S. _Went from this ( - ) to this ( &mdash; )._